### PR TITLE
Add mousetrap as an NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Executable Specification authoring and running",
   "dependencies": {
+    "mousetrap": "^1.5.2",
     "react": "^0.12.2"
   },
   "scripts": {


### PR DESCRIPTION
`npm run harness` was breaking because moustrap wasn't added as a dependency in the package.json.